### PR TITLE
Added the generation of the schema as composer compile task

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,10 @@
         "civicrm-asset": {
             "path": "web/assets/civicrm",
             "url": "/assets/civicrm"
-        }
+        },
+        "compile": [
+            {"run": "@sh cd vendor/civicrm/civicrm-core/xml ; php GenCode.php 0 0 Standalone"}
+        ]
     },
     "prefer-stable": true,
     "minimum-stability": "dev"


### PR DESCRIPTION
Just for convenience, after the composer install it's not needed any more to execute manually the `php GenCode.php` (For people that do not read the instructions)